### PR TITLE
Fix code scanning alert no. 1: CSRF protection not enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  #protect_from_forgery
+  protect_from_forgery with: :exception
   protected
 
   def current_user


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_1/security/code-scanning/1](https://github.com/Brook-5686/Ruby_1/security/code-scanning/1)

To fix the CSRF vulnerability, we need to enable CSRF protection in the `ApplicationController` class. The best way to do this is by uncommenting the `protect_from_forgery` method and specifying the `:exception` strategy, which raises an exception if an invalid CSRF token is provided. This ensures that the application is protected against CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
